### PR TITLE
Fix issues caused by moving to docker + mount mogreps-g

### DIFF
--- a/terraform/modules/dask-scheduler/main.tf
+++ b/terraform/modules/dask-scheduler/main.tf
@@ -1,6 +1,6 @@
 module "dask-bootstrap" {
   source  = "../dask-bootstrap"
-  command = "docker run -d --expose 8787 --expose 8786 -p 8786:8786 -p 8787:8787 --restart always quay.io/informaticslab/asn-serve:v1.0.0 dask-scheduler"
+  command = "docker run -d --expose 8787 --expose 8786 -p 8786:8786 -p 8787:8787 --restart always quay.io/informaticslab/asn-serve:v1.0.0 dask-scheduler --port 8786 --bokeh-port 8787"
 }
 
 resource "aws_security_group" "dask-scheduler" {

--- a/terraform/modules/dask-worker/main.tf
+++ b/terraform/modules/dask-worker/main.tf
@@ -11,6 +11,8 @@ docker run
 quay.io/informaticslab/asn-serve:v1.0.0 -c
 "mkdir -p /usr/local/share/notebooks/data/mogreps &&
 s3fs mogreps /usr/local/share/notebooks/data/mogreps -o iam_role=jade-secrets &&
+mkdir -p /usr/local/share/notebooks/data/mogreps-g &&
+s3fs mogreps-g /usr/local/share/notebooks/data/mogreps-g -o iam_role=jade-secrets &&
 dask-worker ${var.scheduler_address}:8786"
 EOF
 }

--- a/terraform/modules/dask-worker/main.tf
+++ b/terraform/modules/dask-worker/main.tf
@@ -8,7 +8,7 @@ docker run
 --device /dev/fuse
 --cap-add MKNOD
 --entrypoint /bin/bash
-quay.io/informaticslab/asn-serve:v1.0.0 -c
+quay.io/informaticslab/asn-serve:v1.0.1 -c
 "mkdir -p /usr/local/share/notebooks/data/mogreps &&
 s3fs mogreps /usr/local/share/notebooks/data/mogreps -o iam_role=jade-secrets &&
 mkdir -p /usr/local/share/notebooks/data/mogreps-g &&

--- a/terraform/modules/dask-worker/main.tf
+++ b/terraform/modules/dask-worker/main.tf
@@ -8,14 +8,25 @@ docker run
 --device /dev/fuse
 --cap-add MKNOD
 --entrypoint /bin/bash
+--expose 39625
+--expose 33270
+--expose 42786
+--expose 8789
+-p 39625:39625
+-p 33270:33270
+-p 42786:42786
+-p 8789:8789
 quay.io/informaticslab/asn-serve:v1.0.1 -c
 "mkdir -p /usr/local/share/notebooks/data/mogreps &&
 s3fs mogreps /usr/local/share/notebooks/data/mogreps -o iam_role=jade-secrets &&
 mkdir -p /usr/local/share/notebooks/data/mogreps-g &&
 s3fs mogreps-g /usr/local/share/notebooks/data/mogreps-g -o iam_role=jade-secrets &&
-dask-worker ${var.scheduler_address}:8786"
+dask-worker ${var.scheduler_address}:8786 --host $(wget -qO- http://instance-data/latest/meta-data/local-ipv4) --worker-port 39625 --http-port 33270 --nanny-port 42786 --bokeh-port 8789"
 EOF
 }
+
+
+
 
 resource "aws_launch_configuration" "dask-workers" {
   # Amazon Linux ami


### PR DESCRIPTION
Fix the issues that were caused by moving to docker containers for the workers and scheduler. Fix was to fix the ports used by distributed so that they could be enabled in docker. Also use the `--host` flag to ensure the worker advertises its AWS IP rather than it's docker one.