### PR TITLE
Add an alternative Kubernetes implementation which uses adaptive workers

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,7 @@
+```shell
+kubectl create -f namespace.yaml
+kubectl create configmap scheduler --from-file=adaptive.py --from-file=run.sh  --namespace=dask
+kubectl create -f deployment.yaml
+kubectl create -f service.yaml
+kubectl create -f ingress.yaml
+```

--- a/kubernetes/adaptive.py
+++ b/kubernetes/adaptive.py
@@ -1,0 +1,34 @@
+from distributed.deploy import Adaptive
+# from kubernetes import client, config
+from tornado import gen
+
+
+class MyCluster(object):
+    def scale_up(self, n):
+        """
+        Bring the total count of workers up to ``n``
+
+        This function/coroutine should bring the total number of workers up to
+        the number ``n``.
+
+        This can be implemented either as a function or as a Tornado coroutine.
+        """
+        pass
+
+
+    def scale_down(self, workers):
+        """
+        Remove ``workers`` from the cluster
+
+        Given a list of worker addresses this function should remove those
+        workers from the cluster.  This may require tracking which jobs are
+        associated to which worker address.
+
+        This can be implemented either as a function or as a Tornado coroutine.
+        """
+        pass
+
+
+def dask_setup(scheduler):
+    cluster = MyCluster()
+    # adapative_cluster = Adaptive(scheduler, cluster)

--- a/kubernetes/adaptive.py
+++ b/kubernetes/adaptive.py
@@ -1,9 +1,22 @@
+import logging
+import os
+
 from distributed.deploy import Adaptive
-# from kubernetes import client, config
-from tornado import gen
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
 
 
-class MyCluster(object):
+logger = logging.getLogger("distributed.deploy.adaptive")
+
+
+class KubeCluster(object):
+    def __init__(self, **kwargs):
+        config.load_incluster_config()
+        self.api_instance = client.ExtensionsV1beta1Api()
+        self.namespace = 'dask'
+        self.deployment = 'dask-workers'
+        logger.info("Initialising kubernetes scaler")
+
     def scale_up(self, n):
         """
         Bring the total count of workers up to ``n``
@@ -13,8 +26,16 @@ class MyCluster(object):
 
         This can be implemented either as a function or as a Tornado coroutine.
         """
-        pass
-
+        logger.info("Scaling up")
+        current_deployment = self.api_instance.read_namespaced_deployments_scale(self.deployment, self.namespace)
+        logger.info("Current number of workers is %s", current_deployment.spec.replicas)
+        current_deployment.spec.replicas = n
+        logger.info("Scaling to %s}", current_deployment.spec.replicas)
+        try:
+            self.api_instance.replace_namespaced_deployments_scale(
+                self.deployment, self.namespace, current_deployment)
+        except ApiException as e:
+            logger.error("Exception when scaling up {}: {}".format(self.deployment, e))
 
     def scale_down(self, workers):
         """
@@ -26,9 +47,21 @@ class MyCluster(object):
 
         This can be implemented either as a function or as a Tornado coroutine.
         """
-        pass
+        logger.info("Scaling down")
+        # if workers:
+        current_deployment = self.api_instance.read_namespaced_deployments_scale(self.deployment, self.namespace)
+        if current_deployment.spec.replicas is None:
+            current_deployment.spec.replicas = 0
+        logger.info("Current number of workers is %s", current_deployment.spec.replicas)
+        current_deployment.spec.replicas = current_deployment.spec.replicas - len(workers)
+        logger.info("Scaling to %s", current_deployment.spec.replicas)
+        try:
+            self.api_instance.replace_namespaced_deployments_scale(
+                self.deployment, self.namespace, current_deployment)
+        except ApiException as e:
+            logger.error("Exception when scaling up {}: {}".format(self.deployment, e))
 
 
 def dask_setup(scheduler):
-    cluster = MyCluster()
-    # adapative_cluster = Adaptive(scheduler, cluster)
+    cluster = KubeCluster()
+    adapative_cluster = Adaptive(scheduler, cluster)

--- a/kubernetes/adaptive.py
+++ b/kubernetes/adaptive.py
@@ -30,7 +30,7 @@ class KubeCluster(object):
         current_deployment = self.api_instance.read_namespaced_deployments_scale(self.deployment, self.namespace)
         logger.info("Current number of workers is %s", current_deployment.spec.replicas)
         current_deployment.spec.replicas = n
-        logger.info("Scaling to %s}", current_deployment.spec.replicas)
+        logger.info("Scaling to %s", current_deployment.spec.replicas)
         try:
             self.api_instance.replace_namespaced_deployments_scale(
                 self.deployment, self.namespace, current_deployment)
@@ -48,18 +48,20 @@ class KubeCluster(object):
         This can be implemented either as a function or as a Tornado coroutine.
         """
         logger.info("Scaling down")
-        # if workers:
-        current_deployment = self.api_instance.read_namespaced_deployments_scale(self.deployment, self.namespace)
-        if current_deployment.spec.replicas is None:
-            current_deployment.spec.replicas = 0
-        logger.info("Current number of workers is %s", current_deployment.spec.replicas)
-        current_deployment.spec.replicas = current_deployment.spec.replicas - len(workers)
-        logger.info("Scaling to %s", current_deployment.spec.replicas)
-        try:
-            self.api_instance.replace_namespaced_deployments_scale(
-                self.deployment, self.namespace, current_deployment)
-        except ApiException as e:
-            logger.error("Exception when scaling up {}: {}".format(self.deployment, e))
+        if workers:
+            current_deployment = self.api_instance.read_namespaced_deployments_scale(self.deployment, self.namespace)
+            if current_deployment.spec.replicas is None:
+                current_deployment.spec.replicas = 0
+            logger.info("Current number of workers is %s", current_deployment.spec.replicas)
+            current_deployment.spec.replicas = current_deployment.spec.replicas - len(workers)
+            logger.info("Scaling to %s", current_deployment.spec.replicas)
+            try:
+                self.api_instance.replace_namespaced_deployments_scale(
+                    self.deployment, self.namespace, current_deployment)
+            except ApiException as e:
+                logger.error("Exception when scaling up {}: {}".format(self.deployment, e))
+        else:
+            logger.info("Nothing to do")
 
 
 def dask_setup(scheduler):

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -1,0 +1,22 @@
+# Ingress
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dask-dashboard.informaticslab.co.uk
+  namespace: dask
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - hosts:
+    - dask-dashboard.informaticslab.co.uk
+    secretName: dask-dashboard-tls
+  rules:
+  - host: dask-dashboard.informaticslab.co.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: dask-scheduler-dashboard
+          servicePort: 80

--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,0 +1,5 @@
+# Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dask

--- a/kubernetes/run.sh
+++ b/kubernetes/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Install deps
+pip install kubernetes
+
+# Start scheduler
+dask-scheduler --port 8786 --bokeh-port 8787 --preload /opt/scheduler/adaptive.py
+# dask-scheduler --port 8786 --bokeh-port 8787

--- a/kubernetes/scheduler.yaml
+++ b/kubernetes/scheduler.yaml
@@ -11,6 +11,8 @@ spec:
       labels:
         app: dask-scheduler
     spec:
+      serviceAccountName: dask-autoscaler
+      automountServiceAccountToken: true
       containers:
         - image: daskdev/dask:latest
           command: ["/bin/bash"]
@@ -31,3 +33,34 @@ spec:
         - name: config-volume
           configMap:
             name: scheduler
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dask-autoscaler
+  namespace: dask
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: dask
+  name: dask-autoscaler
+rules:
+- apiGroups: [""]
+  resources: ["deployment"]
+  resourceNames: ["dask-workers"]
+  verbs: ["update", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: dask-autoscaler
+  namespace: dask
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dask-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: dask-autoscaler
+    namespace: dask

--- a/kubernetes/scheduler.yaml
+++ b/kubernetes/scheduler.yaml
@@ -1,0 +1,33 @@
+# Deployment
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: dask-scheduler
+  namespace: dask
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: dask-scheduler
+    spec:
+      containers:
+        - image: daskdev/dask:latest
+          command: ["/bin/bash"]
+          args: ["/opt/scheduler/run.sh"]
+          imagePullPolicy: Always
+          name: dask-scheduler
+          ports:
+            - containerPort: 8787
+            - containerPort: 8786
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /opt/scheduler
+      volumes:
+        - name: config-volume
+          configMap:
+            name: scheduler

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,0 +1,25 @@
+# Service
+kind: Service
+metadata:
+  name: dask-scheduler-dashboard
+  namespace: dask
+spec:
+  ports:
+    - port: 80
+      targetPort: 8787
+      protocol: TCP
+  selector:
+    app: dask-scheduler
+---
+# Service
+kind: Service
+metadata:
+  name: dask-scheduler
+  namespace: dask
+spec:
+  ports:
+    - port: 8786
+      targetPort: 8786
+      protocol: TCP
+  selector:
+    app: dask-scheduler

--- a/kubernetes/worker.yaml
+++ b/kubernetes/worker.yaml
@@ -31,3 +31,13 @@ spec:
             requests:
               cpu: 100m
               memory: 1Gi
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: no-worker-disruption
+spec:
+  selector:
+    matchLabels:
+      app: dask-workers
+  minAvailable: 100%

--- a/kubernetes/worker.yaml
+++ b/kubernetes/worker.yaml
@@ -1,0 +1,33 @@
+# Deployment
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: dask-workers
+  namespace: dask
+spec:
+  replicas: 0
+  template:
+    metadata:
+      labels:
+        app: dask-workers
+    spec:
+      containers:
+        - image: daskdev/dask:latest
+          command: ["sh", "-c"]
+          args:
+            - dask-worker $DASK_SCHEDULER_SERVICE_HOST:$DASK_SCHEDULER_SERVICE_PORT --nprocs 1 --nthreads 1 --host $POD_IP --name $POD_NAME
+          imagePullPolicy: Always
+          name: dask-worker
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi


### PR DESCRIPTION
This PR adds a kubernetes directory with kube config files for creating a scheduler and adaptive workers on a kubernetes cluster. _This is separate from the terraform implementation._

The config will create a new namespace on kubernetes for the cluster. It will create a scheduler and a scaling group for workers (defaulting to zero workers). It also adds a role so that the scheduler can scale the workers automatically. 

The scheduler status page will be exposed externally at https://dask-dashboard.informaticslab.co.uk and the scheduler itself will be available internally to the kubernetes cluster at `dask-scheduler.dask:8686`.

When connecting to the scheduler it will show zero workers. But when you submit a task it begins to request more workers, doubling each time it feels it needs more. 

If the kubernetes cluster is configured to autoscale correctly the workers will fill all available space on the cluster and trigger the autoscaling causing new nodes will be added, allowing dask to continue scaling.

Once the task has finished all workers will be removed again except any that are holding the final result (usually just one). This will leave lots of empty space in the kubernetes cluster and the autoscaling should begin reclaiming that space by shutting down the nodes and migrating containers running on them.

The workers are configured with a `DisruptionBudget` of 100% to avoid kubernetes trying to migrate the worker holding the final answer as that will cause the answer to be lost and distributed will trigger the whole calculation again.